### PR TITLE
Update hull-node versions and small refactor

### DIFF
--- a/src/checks/hull-node-version.js
+++ b/src/checks/hull-node-version.js
@@ -2,20 +2,15 @@ const fs = require("fs");
 
 module.exports = function checkPackageEngines() {
 
+  const allowedVersions = ["0.13.6", "0.12.7", "0.11.13"];
+
   const packageJson = JSON.parse(fs.readFileSync(`${process.cwd()}/package.json`, "utf-8"));
   const { hull } = packageJson.dependencies;
-  if (hull === "0.13.5") {
-    return true;
-  }
 
-  if (hull === "0.12.7") {
-    return true;
-  }
-
-  if (hull === "0.11.13") {
+  if(allowedVersions.includes(hull)) {
     return true;
   }
 
   return `\`hull-node\` version is ${hull},
-  should be 0.13.5, 0.12.7 or 0.11.13`;
+  should be one of the following: ${allowedVersions.join(",")}`;
 };


### PR DESCRIPTION
@michaloo, I made a small refactoring for the hull-node check and updated the version from `0.13.5` to `0.13.6`. I have `hull-nutshell` on `v0.13.6` which makes the test fail.